### PR TITLE
Refactor/제스처 입력 방식을 JSON → CSV 파일 업로드 방식으로 변경#9

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,8 @@
 #app/utils.py
 import numpy as np
+from tensorflow.keras.preprocessing.sequence import pad_sequences
+
+
 
 def trim_zero_padding(sequence: np.ndarray) -> np.ndarray:
     non_zero_mask = np.any(sequence != 0, axis=1)
@@ -85,25 +88,25 @@ def sliding_window_gesture_detection(
     final = filter_short_intervals(merged, min_interval_length)
     return final
 
-def clean_json_sequence(sequence: list[list[float]], expected_length: int = None) -> np.ndarray:
+def clean_json_sequence(
+        sequence: list[list[float]],
+        expected_length: int = None,
+        max_seq_len: int = None
+) -> np.ndarray:
     if expected_length is None and len(sequence) > 0:
-        expected_length = len(sequence[0])  # 첫 프레임의 길이를 기준으로 사용
+        expected_length = len(sequence[0])
 
     cleaned = []
-
     for i, row in enumerate(sequence):
         if not isinstance(row, list):
             raise ValueError(f"Row {i} is not a list.")
 
-        row_len = len(row)
+        row = row[:expected_length] + [0.0] * max(0, expected_length - len(row))
+        cleaned.append(row)
 
-        if row_len < expected_length:
-            padded = row + [0.0] * (expected_length - row_len)
-            cleaned.append(padded)
-        elif row_len > expected_length:
-            trimmed = row[:expected_length]
-            cleaned.append(trimmed)
-        else:
-            cleaned.append(row)
+    arr = np.array(cleaned, dtype=np.float32)
 
-    return np.array(cleaned, dtype=np.float32)
+    if max_seq_len is not None:
+        arr = pad_sequences([arr], maxlen=max_seq_len, dtype='float32', padding='post', truncating='post')[0]
+
+    return arr

--- a/main.py
+++ b/main.py
@@ -1,30 +1,26 @@
-# main.py
-import numpy as np
-import os
-import uvicorn
-import base64
-
-from fastapi import FastAPI, HTTPException
+#main.py
+from fastapi import FastAPI, HTTPException, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
-
 from pydantic import BaseModel
 from typing import List
+import numpy as np
+import pandas as pd
+import base64
+import io
 
-from app.utils import clean_json_sequence, trim_zero_padding, sliding_window_gesture_detection
+from app.utils import trim_zero_padding, sliding_window_gesture_detection
 from app.model_loader import load_models
 from app.gpt_router import router as gpt_router
 from app.converter import convert_gestures_to_sentence
 from app.tts import generate_tts
-
 
 app = FastAPI()
 
 # 정적 파일 제공
 app.mount("/tts_audios", StaticFiles(directory="tts_audios"), name="tts")
 
-# 루트 리다이렉션
 @app.get("/", include_in_schema=False)
 async def root():
     return RedirectResponse(url="/docs")
@@ -37,17 +33,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Gemini 변환 라우터 포함
 app.include_router(gpt_router)
 
-# 모델 초기 로딩
+# 모델 로딩
 encoder_model, gesture_hmms, ergodic_model = load_models()
 
-
-# 요청 및 응답 스키마
-class SequenceRequest(BaseModel):
-    sequence: List[List[float]]
-
+# 응답 스키마 정의
 class Interval(BaseModel):
     start: int
     end: int
@@ -63,15 +54,15 @@ class TranslateResponse(BaseModel):
 class TTSRequest(BaseModel):
     sentence: str
 
-
-# 제스처 시퀀스를 제스처 라벨로 변환
-@app.post("/predict_gesture", response_model=GestureResponse)
-async def predict_gesture(req: SequenceRequest):
+# CSV 파일로 제스처 인식
+@app.post("/predict_gesture_from_csv", response_model=GestureResponse)
+async def predict_gesture_from_csv(file: UploadFile = File(...)):
     try:
-        expected_length = encoder_model.input_shape[2]
-        sequence = clean_json_sequence(req.sequence, expected_length=expected_length)
-        trimmed = trim_zero_padding(sequence)
+        contents = await file.read()
+        df = pd.read_csv(io.BytesIO(contents))
+        data = df.values.astype(np.float32)
 
+        trimmed = trim_zero_padding(data)
         intervals = sliding_window_gesture_detection(
             continuous_sequence=trimmed,
             encoder_model=encoder_model,
@@ -79,7 +70,7 @@ async def predict_gesture(req: SequenceRequest):
             final_model=ergodic_model,
             window_size=20,
             step=2,
-            threshold_diff=-300.0,
+            threshold_diff=0.0,
             min_merge_gap=3,
             min_interval_length=3
         )
@@ -91,18 +82,15 @@ async def predict_gesture(req: SequenceRequest):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-
-# 제스처 → 문장 변환
-@app.post(
-    "/predict_gesture_and_sentence",
-    summary="제스처 시퀀스를 자연어 문장으로 변환",
-    tags=["Gesture → Sentence"]
-)
-async def predict_gesture_and_sentence(req: SequenceRequest):
+# CSV 파일로 제스처 → 문장
+@app.post("/predict_gesture_and_sentence_from_csv", summary="CSV 기반 제스처를 문장으로 변환", tags=["Gesture → Sentence"])
+async def predict_gesture_and_sentence_from_csv(file: UploadFile = File(...)):
     try:
-        sequence = clean_json_sequence(req.sequence, expected_length=126)
-        trimmed = trim_zero_padding(sequence)
+        contents = await file.read()
+        df = pd.read_csv(io.BytesIO(contents))
+        data = df.values.astype(np.float32)
 
+        trimmed = trim_zero_padding(data)
         intervals = sliding_window_gesture_detection(
             continuous_sequence=trimmed,
             encoder_model=encoder_model,
@@ -111,8 +99,8 @@ async def predict_gesture_and_sentence(req: SequenceRequest):
             window_size=20,
             step=2,
             threshold_diff=0.0,
-            min_merge_gap=5,
-            min_interval_length=5,
+            min_merge_gap=3,
+            min_interval_length=3
         )
 
         gestures = [label for _, _, label in intervals] or ["none"]
@@ -123,14 +111,8 @@ async def predict_gesture_and_sentence(req: SequenceRequest):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-
-# 문장 → TTS 변환
-@app.post(
-    "/generate_tts",
-    response_model=TranslateResponse,
-    summary="자연어 문장을 TTS 음성(base64)으로 변환",
-    tags=["TTS"]
-)
+# TTS
+@app.post("/generate_tts", response_model=TranslateResponse, summary="자연어 문장을 TTS 음성(base64)으로 변환", tags=["TTS"])
 async def generate_tts_audio(data: TTSRequest):
     try:
         sentence = data.sentence
@@ -147,7 +129,7 @@ async def generate_tts_audio(data: TTSRequest):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-
 # 실행
 if __name__ == "__main__":
+    import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ openai==0.28
 python-dotenv
 google-generativeai
 gTTS
+tensorflow>=2.11
+keras>=2.11
+pandas
+python-multipart


### PR DESCRIPTION
#️⃣ 연관된 이슈
- #9 

📝 작업 내용
1. CSV 기반 입력 방식으로 엔드포인트 추가
- UploadFile을 통해 CSV 파일을 업로드받아 Pandas로 파싱 후 NumPy 배열로 변환
- 기존 JSON 기반 제스처 입력을 대체하거나 병행 가능하도록 /predict_gesture_from_csv, /predict_gesture_and_sentence_from_csv 두 API 구성

2. 기존 인식 파이프라인과 통합
- 업로드된 CSV 데이터를 trim_zero_padding 처리 후
sliding_window_gesture_detection → convert_gestures_to_sentence → 결과 반환
- 인식된 제스처 시퀀스를 문장으로 변환하는 로직은 기존과 동일하게 유지