### PR TITLE
Perf/improve gesture detection speed#11

### DIFF
--- a/app/model_loader.py
+++ b/app/model_loader.py
@@ -7,16 +7,16 @@ MODEL_DIR = "models"
 
 def load_models():
     print("[LOADER] Loading encoder_model.keras...")
-    encoder_model = tf.keras.models.load_model(os.path.join(MODEL_DIR, 'encoder_model.keras'))
+    encoder_model = tf.keras.models.load_model(os.path.join(MODEL_DIR, 'app_encoder_model.keras'))
     print("[LOADER] encoder_model loaded. Input shape:", encoder_model.input_shape)
 
     print("[LOADER] Loading gesture_hmms.pkl...")
-    with open(os.path.join(MODEL_DIR, 'gesture_hmms.pkl'), 'rb') as f:
+    with open(os.path.join(MODEL_DIR, 'app_gesture_hmms.pkl'), 'rb') as f:
         gesture_hmms = pickle.load(f)
     print("[LOADER] gesture_hmms loaded. Gestures:", list(gesture_hmms.keys()))
 
     print("[LOADER] Loading ergodic_model.pkl...")
-    with open(os.path.join(MODEL_DIR, 'ergodic_model.pkl'), 'rb') as f:
+    with open(os.path.join(MODEL_DIR, 'app_ergodic_model.pkl'), 'rb') as f:
         ergodic_model = pickle.load(f)
     print("[LOADER] ergodic_model loaded.")
     return encoder_model, gesture_hmms, ergodic_model

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,8 @@
 #app/utils.py
 import numpy as np
+import datetime
 from tensorflow.keras.preprocessing.sequence import pad_sequences
-
+from typing import List, Tuple
 
 
 def trim_zero_padding(sequence: np.ndarray) -> np.ndarray:
@@ -36,54 +37,66 @@ def sliding_window_gesture_detection(
         threshold_diff: float = 3.0,
         min_merge_gap: int = 5,
         min_interval_length: int = 5,
-) -> list[tuple[int, int, str]]:
+        debug: bool = False,
+) -> List[Tuple[int, int, str]]:
     T = continuous_sequence.shape[0]
     if T < window_size:
         return []
 
     MAX_SEQ_LEN = encoder_model.input_shape[1]
     NUM_FEATURES = encoder_model.input_shape[2]
-
     gesture_names = list(gesture_hmms.keys())
-    detected = []
-    n_windows = (T - window_size) // step + 1
 
+    # Step 1: Collect all windows and pad
+    n_windows = (T - window_size) // step + 1
+    all_padded = []
     for w in range(n_windows):
         start = w * step
         end = start + window_size
         window = continuous_sequence[start:end, :]
-
-        if window.shape[0] < MAX_SEQ_LEN:
-            pad_len = MAX_SEQ_LEN - window.shape[0]
+        pad_len = MAX_SEQ_LEN - window.shape[0]
+        if pad_len > 0:
             padded = np.vstack([window, np.zeros((pad_len, NUM_FEATURES), dtype=window.dtype)])
         else:
             padded = window[:MAX_SEQ_LEN, :]
+        all_padded.append(padded)
 
-        latent_seq = encoder_model.predict(padded[np.newaxis, ...])[0]
-        lengths = [MAX_SEQ_LEN]
+    batched = np.stack(all_padded)  # shape: (n_windows, MAX_SEQ_LEN, NUM_FEATURES)
 
-        f_ll = final_model.score(latent_seq, lengths)
+    # Step 2: Batch predict latent sequences
+    latent_seqs = encoder_model.predict(batched, verbose=0)  # shape: (n_windows, MAX_SEQ_LEN, latent_dim)
+    lengths = [MAX_SEQ_LEN] * n_windows
 
-        max_diff = -np.inf
+    # Step 3: Score using final model
+    final_scores = [final_model.score(seq, [MAX_SEQ_LEN]) for seq in latent_seqs]
+
+    # Step 4: Detect gestures
+    detected = []
+    for i, (latent_seq, f_ll) in enumerate(zip(latent_seqs, final_scores)):
         best_label = None
+        max_diff = -np.inf
+        scores = {}
+
         for name in gesture_names:
-            g_ll = gesture_hmms[name].score(latent_seq, lengths)
+            g_ll = gesture_hmms[name].score(latent_seq, [MAX_SEQ_LEN])
             diff = g_ll - f_ll
+            scores[name] = (g_ll, diff)
             if diff > max_diff:
                 max_diff = diff
                 best_label = name
 
-        print(f"[DEBUG] w={w:03d} | f_ll={f_ll:.2f} | max_diff={max_diff:.2f} → {best_label}")
-        for name in gesture_names:
-            g_ll = gesture_hmms[name].score(latent_seq, lengths)
-            diff = g_ll - f_ll
-            print(f"    → {name:<10}: g_ll={g_ll:.2f}, diff={diff:.2f}")
+        if debug:
+            print(f"[DEBUG] w={i:03d} | f_ll={f_ll:.2f} | max_diff={max_diff:.2f} → {best_label}")
+            for name in gesture_names:
+                g_ll, diff = scores[name]
+                print(f"    → {name:<10}: g_ll={g_ll:.2f}, diff={diff:.2f}")
 
         if max_diff >= threshold_diff:
+            start = i * step
+            end = start + window_size
             detected.append((start, end, best_label))
 
-        print(f"[DEBUG] w={w:03d}, max_diff={max_diff:.2f}, best_label={best_label}, f_ll={f_ll:.2f}")
-
+    # Step 5: Merge and filter results
     merged = merge_gesture_intervals(detected, min_merge_gap)
     final = filter_short_intervals(merged, min_interval_length)
     return final

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import base64
 import io
+import datetime
 
 from app.utils import trim_zero_padding, sliding_window_gesture_detection
 from app.model_loader import load_models
@@ -63,17 +64,21 @@ async def predict_gesture_from_csv(file: UploadFile = File(...)):
         data = df.values.astype(np.float32)
 
         trimmed = trim_zero_padding(data)
+
+        t1 = datetime.datetime.now()
         intervals = sliding_window_gesture_detection(
             continuous_sequence=trimmed,
             encoder_model=encoder_model,
             gesture_hmms=gesture_hmms,
             final_model=ergodic_model,
-            window_size=20,
+            window_size=10,
             step=2,
             threshold_diff=0.0,
             min_merge_gap=3,
             min_interval_length=3
         )
+        t2 = datetime.datetime.now()
+        print("수화인식 결과 반환api",t2-t1)
 
         return GestureResponse(
             intervals=[Interval(start=int(s), end=int(e), label=l) for s, e, l in intervals]
@@ -91,17 +96,21 @@ async def predict_gesture_and_sentence_from_csv(file: UploadFile = File(...)):
         data = df.values.astype(np.float32)
 
         trimmed = trim_zero_padding(data)
+
+        t1 = datetime.datetime.now()
         intervals = sliding_window_gesture_detection(
             continuous_sequence=trimmed,
             encoder_model=encoder_model,
             gesture_hmms=gesture_hmms,
             final_model=ergodic_model,
-            window_size=20,
+            window_size=10,
             step=2,
             threshold_diff=0.0,
             min_merge_gap=3,
             min_interval_length=3
         )
+        t2 = datetime.datetime.now()
+        print("결과",t2-t1)
 
         gestures = [label for _, _, label in intervals] or ["none"]
         sentence = convert_gestures_to_sentence(gestures)


### PR DESCRIPTION
### 연관된 이슈
- #11 

### 작업내용
1.sliding_window_gesture_detection 성능 개선
반복적으로 encoder_model.predict()를 호출하던 방식에서 → 배치 예측 방식으로 변경
모든 윈도우를 한 번에 np.stack()으로 묶어 encoder_model.predict()를 1회 호출
인식 정확도는 동일하게 유지하면서 속도 대폭 향상

2. 디버그 출력 제어 기능 추가
debug: bool = False 파라미터 추가
필요할 때만 각 윈도우별 score 및 best label 출력 가능

3. 제스처 탐지 파라미터 튜닝 
windowsize : 10으로 변경